### PR TITLE
fix: Remove React from peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Easy next-intl Storybook integration.
 Required Peer Dependencies:
 * storybook - `^8.2.0`
 * next-intl - `^3.0.0`
-* React - `^18 || ^19`
 
 This Storybook addon assumes your project is already set up with [next-intl](https://next-intl-docs.vercel.app/), and that it is properly configured and working.
 

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "zx": "7.2.3"
   },
   "peerDependencies": {
-    "next-intl": "^3",
-    "react": "^18 || ^19"
+    "next-intl": "^3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Storybook addon pre-publish check failed as React is provided by Storybook, and it is unnecessary to be a peer dependency. Remove it from the peerDependencies list but still keep it in the tsup external config to fix https://github.com/stevensacks/storybook-next-intl/issues/5

- [Build failure](https://github.com/stevensacks/storybook-next-intl/actions/runs/12061700434/job/33634152458)
- [Related code](https://github.com/stevensacks/storybook-next-intl/blob/main/scripts/prepublish-checks.js#L63-L84)