### PR TITLE
fix(tsup): exclude react from tsup bundle

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -97,7 +97,9 @@ export default defineConfig(async (options) => {
             format: ['esm', 'cjs'],
             target: BROWSER_TARGET,
             platform: 'browser',
-            external: globalPreviewPackages,
+            // Exclude React from the bundle
+            // https://github.com/stevensacks/storybook-next-intl/issues/5
+            external: [...globalPreviewPackages, 'react'],
         });
     }
 


### PR DESCRIPTION
close https://github.com/stevensacks/storybook-next-intl/issues/11

I have checked that `dist/preview.js` and `dist/preview.cjs` doesn't include React anymore after running `npm run build`