### PR TITLE
Build package root export

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,7 +16,12 @@ export default defineConfig(async () => {
         .default;
 
     const {
-        bundler: {managerEntries = [], previewEntries = [], nodeEntries = []},
+        bundler: {
+            exportEntries = [],
+            managerEntries = [],
+            previewEntries = [],
+            nodeEntries = [],
+        },
     } = packageJson;
 
     const commonConfig: Options = {
@@ -36,6 +41,21 @@ export default defineConfig(async () => {
     };
 
     const configs: Options[] = [];
+
+    /*
+     export entries are package-root exports that users or Storybook resolve
+     directly from the addon package. They need declarations generated because
+     package.json points the root export at dist/index.js and dist/index.d.ts.
+    */
+    if (exportEntries.length) {
+        configs.push({
+            ...commonConfig,
+            entry: exportEntries,
+            platform: 'browser',
+            target: 'esnext',
+            dts: true,
+        });
+    }
 
     /*
      manager entries are entries meant to be loaded into the manager UI


### PR DESCRIPTION
## Summary

- include `bundler.exportEntries` in the tsup build config
- generate the package-root `dist/index.js` and `dist/index.d.ts` files that `package.json` already exports
- keep the existing package export map unchanged

This fixes the published package contract where `storybook-next-intl@10.1.1` exports the package root to `./dist/index.js` and `./dist/index.d.ts`, but the build did not emit those files.

Reference: charles-openclaw/charles-microbounties#1202

## Validation

- `npm run build`
- `npm pack --dry-run --json` and checked the tarball includes:
  - `dist/index.js`
  - `dist/index.d.ts`
  - `dist/preview.js`
  - `dist/preview.d.ts`
  - `dist/manager.js`
- packed-package clean install with `storybook`, `next-intl`, `react`, and `react-dom`, then verified:
  - `await import('storybook-next-intl')`
  - `require('storybook-next-intl')`
  - `await import('storybook-next-intl/preview')`
  - `require('storybook-next-intl/preview')`
- `npx prettier --check tsup.config.ts`
- `git diff --check`

Note: `npm run lint` currently fails before linting changed files because this checkout uses ESLint 9.39.1 but does not include an `eslint.config.(js|mjs|cjs)` flat config file.
